### PR TITLE
Send `fullscreen-resize` postMessage so embedded apps can react

### DIFF
--- a/src/aind_qc_portal/view_contents/panels/media/curation_apps/curation.py
+++ b/src/aind_qc_portal/view_contents/panels/media/curation_apps/curation.py
@@ -271,9 +271,8 @@ class EphysCuration(PyComponent):
             f'<iframe id="iframe-0000" src="{processed_url}" '
             f'style="width:100%;height:100%;border: none;" '
             f'allow="cross-origin-isolated"></iframe>',
-            width=1200,
-            height=900,
-            sizing_mode="fixed",
+            sizing_mode="stretch_both",
+            stylesheets=["iframe { min-width: 60vw; min-height: 50vh; }"],
         )
         fullscreen_iframe = Fullscreen(self.iframe_component)
 
@@ -289,11 +288,10 @@ class EphysCuration(PyComponent):
                 self.send_button,
                 self.ephys_sender,
                 self.ephys_listener,
-                max_width=350,
+                max_width=300,
             ),
             pn.Column(
                 fullscreen_iframe,
-                width=1200,
             ),
         )
 
@@ -394,9 +392,12 @@ class EphysCuration(PyComponent):
             "data": curation_data,
             "_nonce": str(uuid4()),  # ensures the JSON is always unique
         }
-        options = list(self.curation_dropdown.options)
-        curation_entry = options[self.selected_curation_index]
-        print(f"EphysCuration: Sending curation data {curation_entry} to iframe (identifier: {identifier})")
+        if len(curation_data) == 0:
+            print(f"EphysCuration: Sending empty curation data to iframe (identifier: {identifier})")
+        else:
+            options = list(self.curation_dropdown.options)
+            curation_entry = options[self.selected_curation_index]
+            print(f"EphysCuration: Sending curation data {curation_entry} to iframe (identifier: {identifier})")
 
         # Append a unique counter so the param change always fires
         self.ephys_sender.message_json = json.dumps(envelope)

--- a/src/aind_qc_portal/view_contents/panels/media/curation_apps/curation.py
+++ b/src/aind_qc_portal/view_contents/panels/media/curation_apps/curation.py
@@ -12,7 +12,7 @@ from panel.custom import PyComponent, ReactComponent
 from aind_qc_portal.view_contents.panels.media.media import Media
 from aind_qc_portal.view_contents.panels.media.utils import Fullscreen
 
-DEBUG_EPHYS = True
+DEBUG_EPHYS = False
 EPHYS_LOCALPORT = 5010
 
 

--- a/src/aind_qc_portal/view_contents/panels/media/curation_apps/curation.py
+++ b/src/aind_qc_portal/view_contents/panels/media/curation_apps/curation.py
@@ -12,7 +12,7 @@ from panel.custom import PyComponent, ReactComponent
 from aind_qc_portal.view_contents.panels.media.media import Media
 from aind_qc_portal.view_contents.panels.media.utils import Fullscreen
 
-DEBUG_EPHYS = False
+DEBUG_EPHYS = True
 EPHYS_LOCALPORT = 5010
 
 
@@ -392,12 +392,9 @@ class EphysCuration(PyComponent):
             "data": curation_data,
             "_nonce": str(uuid4()),  # ensures the JSON is always unique
         }
-        if len(curation_data) == 0:
-            print(f"EphysCuration: Sending empty curation data to iframe (identifier: {identifier})")
-        else:
-            options = list(self.curation_dropdown.options)
-            curation_entry = options[self.selected_curation_index]
-            print(f"EphysCuration: Sending curation data {curation_entry} to iframe (identifier: {identifier})")
+        options = list(self.curation_dropdown.options)
+        curation_entry = options[self.selected_curation_index]
+        print(f"EphysCuration: Sending curation data {curation_entry} to iframe (identifier: {identifier})")
 
         # Append a unique counter so the param change always fires
         self.ephys_sender.message_json = json.dumps(envelope)

--- a/src/aind_qc_portal/view_contents/panels/media/utils.py
+++ b/src/aind_qc_portal/view_contents/panels/media/utils.py
@@ -184,10 +184,104 @@ function requestFullScreen(element) {
     }
 }
 
+function findIframesDeep(root) {
+    const results = [];
+    root.querySelectorAll('iframe').forEach(function(el) { results.push(el); });
+    root.querySelectorAll('*').forEach(function(el) {
+        if (el.shadowRoot) {
+            findIframesDeep(el.shadowRoot).forEach(function(f) { results.push(f); });
+        }
+    });
+    return results;
+}
+
+function applyToAllDeep(root, w, h) {
+    root.querySelectorAll('*').forEach(function(el) {
+        if (el.tagName === 'IMG' || el.tagName === 'VIDEO' || el.tagName === 'SVG') return;
+        if (el.tagName !== 'IFRAME') {
+            el.style.setProperty('width',      w + 'px', 'important');
+            el.style.setProperty('height',     h + 'px', 'important');
+            el.style.setProperty('min-width',  '0',      'important');
+            el.style.setProperty('min-height', '0',      'important');
+            el.style.setProperty('overflow',   'hidden',  'important');
+        }
+        if (el.shadowRoot) {
+            applyToAllDeep(el.shadowRoot, w, h);
+        }
+    });
+}
+
+function clearAllDeep(root) {
+    root.querySelectorAll('*').forEach(function(el) {
+        el.style.removeProperty('width');
+        el.style.removeProperty('height');
+        el.style.removeProperty('min-width');
+        el.style.removeProperty('min-height');
+        el.style.removeProperty('overflow');
+        if (el.shadowRoot) { clearAllDeep(el.shadowRoot); }
+    });
+}
+
+function applyFullscreenSizes(container) {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    container.style.setProperty('width',  w + 'px', 'important');
+    container.style.setProperty('height', h + 'px', 'important');
+    const objectContainer = container.querySelector('.object-container');
+    if (!objectContainer) return;
+    objectContainer.style.setProperty('width',  w + 'px', 'important');
+    objectContainer.style.setProperty('height', h + 'px', 'important');
+    applyToAllDeep(objectContainer, w, h);
+    findIframesDeep(objectContainer).forEach(function(iframe) {
+        iframe.style.setProperty('width',      w + 'px', 'important');
+        iframe.style.setProperty('height',     h + 'px', 'important');
+        iframe.style.setProperty('min-width',  '0',      'important');
+        iframe.style.setProperty('min-height', '0',      'important');
+    });
+    setTimeout(function() {
+        const iframes = findIframesDeep(container);
+        console.log('[Fullscreen] sending fullscreen-resize to', iframes.length, 'iframe(s)');
+        iframes.forEach(function(iframe) {
+            if (iframe.contentWindow) {
+                console.log('[Fullscreen] postMessage → ', iframe.src);
+                iframe.contentWindow.postMessage({ type: 'fullscreen-resize' }, '*');
+            }
+        });
+    }, 200);
+}
+
+function clearFullscreenSizes(container) {
+    container.style.removeProperty('width');
+    container.style.removeProperty('height');
+    const objectContainer = container.querySelector('.object-container');
+    if (objectContainer) {
+        objectContainer.style.removeProperty('width');
+        objectContainer.style.removeProperty('height');
+        clearAllDeep(objectContainer);
+    }
+    setTimeout(function() {
+        findIframesDeep(container).forEach(function(iframe) {
+            if (iframe.contentWindow) {
+                iframe.contentWindow.postMessage({ type: 'fullscreen-resize' }, '*');
+            }
+        });
+    }, 200);
+}
+
+function onFullscreenChange() {
+    if (document.fullscreenElement) {
+        applyFullscreenSizes(button.parentElement);
+    } else {
+        clearFullscreenSizes(button.parentElement);
+        document.removeEventListener('fullscreenchange', onFullscreenChange);
+    }
+}
+
 function toggleFullScreen() {
     if (isFullScreen()) {
         exitFullScreen()
     } else {
+        document.addEventListener('fullscreenchange', onFullscreenChange);
         requestFullScreen(button.parentElement)
     }
 }


### PR DESCRIPTION
Fixes #155 

The issue with fullscreen and embedded apps is that if the embedded panel app (e.g. ephys GUI) renders while not in full screen, its window sizes are not updated when toggling full screen.

The solution proposed here is to send a `fullscreen-resize` type message to all iframes, so that they can react.

For the Ephys GUI, this is taken care of here: https://github.com/AllenNeuralDynamics/aind-ephys-portal/pull/18

In action:
[Screencast from 2026-04-01 15-10-55.webm](https://github.com/user-attachments/assets/620f2152-8e8c-4d8c-97c2-66c62c401750)

